### PR TITLE
FIX: Prevent errors when an extractor isn’t available

### DIFF
--- a/code/extensions/FileTextExtractable.php
+++ b/code/extensions/FileTextExtractable.php
@@ -28,7 +28,7 @@ class FileTextExtractable extends DataExtension {
 
 		// Determine which extractor can process this file.
 		$extractor = FileTextExtractor::for_file($this->owner->FullPath);
-		if (!$extractor) return null;
+		if (!$extractor || !$extractor->isAvailable()) return null;
 
 		$text = $extractor->getContent($this->owner->FullPath);
 		if (!$text) return null;


### PR DESCRIPTION
Before this change, it would loop over all extractors that matched the file extension and attempt extraction, even if they weren’t configured.