### PR TITLE
Check file existence in for_file()

### DIFF
--- a/code/extractors/FileTextExtractor.php
+++ b/code/extractors/FileTextExtractor.php
@@ -72,9 +72,13 @@ abstract class FileTextExtractor extends Object {
 
 	/**
 	 * @param string $path
-	 * @return FileTextExtractor
+	 * @return FileTextExtractor|null
 	 */
 	static function for_file($path) {
+		if(!file_exists($path) || is_dir($path)) {
+			return;
+		}
+
 		$extension = pathinfo($path, PATHINFO_EXTENSION);
 		$mime = self::get_mime($path);
 		foreach(self::get_extractor_classes() as $className) {


### PR DESCRIPTION
finfo() will silently fail the whole request (at least on my PHP 5.4 install)
if invoked on a file that doesn't exist, so fail early here.