### PR TITLE
fix(PDFTextExtractor): Added support for Windows, but only if 'binary_location' config is defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ FileTextCache_SSCache:
 
 PDFs require special handling, for example through the [XPDF](http://www.foolabs.com/xpdf/)
 commandline utility. Follow their installation instructions, its presence will be automatically
-detected. You can optionally set the binary path in `mysite/_config/config.yml`:
+detected for *nix operating systems. You can optionally set the binary path (required for Windows) in `mysite/_config/config.yml`
 
 ```yml
 PDFTextExtractor:

--- a/code/extractors/PDFTextExtractor.php
+++ b/code/extractors/PDFTextExtractor.php
@@ -71,6 +71,9 @@ class PDFTextExtractor extends FileTextExtractor
             if(file_exists($path)) {
                 return $path;
             }
+            if (file_exists($path.'.exe')) {
+                return $path.'.exe';
+            }
         }
         
         // Not found
@@ -100,6 +103,10 @@ class PDFTextExtractor extends FileTextExtractor
         }
         exec(sprintf('%s %s - 2>&1', $this->bin('pdftotext'), escapeshellarg($path)), $content, $err);
         if ($err) {
+            if (!is_array($err) && $err == 1) {
+                // For Windows compatibility
+                $err = $content;
+            }
             throw new FileTextExtractor_Exception(sprintf(
                 'PDFTextExtractor->getContent() failed for %s: %s',
                 $path,


### PR DESCRIPTION
fix(PDFTextExtractor): Added support for Windows, but only if 'binary_location' config is defined.

This could potentially be extended and use apache_getenv('PATH') to automatically search for it on a Windows machine, but I don't have the time.